### PR TITLE
`display` attribute for Math tag

### DIFF
--- a/lib/mml/math_with_namespace.rb
+++ b/lib/mml/math_with_namespace.rb
@@ -8,6 +8,8 @@ module Mml
       attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
     end
 
+    attribute :display, :string
+
     xml do
       root "math", mixed: true
       namespace "http://www.w3.org/1998/Math/MathML", nil
@@ -15,6 +17,8 @@ module Mml
       Mml::Configuration::SUPPORTED_TAGS.each do |tag|
         map_element tag.to_sym, to: :"#{tag}_value"
       end
+
+      map_attribute :display, to: :display
     end
   end
 end

--- a/lib/mml/math_with_nil_namespace.rb
+++ b/lib/mml/math_with_nil_namespace.rb
@@ -8,12 +8,16 @@ module Mml
       attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
     end
 
+    attribute :display, :string
+
     xml do
       root "math", mixed: true
 
       Mml::Configuration::SUPPORTED_TAGS.each do |tag|
         map_element tag.to_sym, to: :"#{tag}_value"
       end
+
+      map_attribute :display, to: :display
     end
   end
 end

--- a/lib/mml/mml.rb
+++ b/lib/mml/mml.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-DEFAULT_ADAPTER = if RUBY_VERSION == "opal"
+DEFAULT_ADAPTER = if RUBY_ENGINE == "opal"
                     require "lutaml/model/xml_adapter/oga_adapter"
                     :oga
                   else

--- a/lib/mml/mn.rb
+++ b/lib/mml/mn.rb
@@ -4,7 +4,7 @@ module Mml
   class Mn < Lutaml::Model::Serializable
     model Mml::Configuration.class_for(:mn)
 
-    attribute :value, :integer
+    attribute :value, :string
     attribute :mathcolor, :string
     attribute :mathbackground, :string
     attribute :mathvariant, :string

--- a/mml.gemspec
+++ b/mml.gemspec
@@ -30,6 +30,6 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "lutaml-model", "~> 0.3"
+  spec.add_runtime_dependency "lutaml-model", "~> 0.5"
   spec.add_runtime_dependency "zeitwerk"
 end

--- a/spec/fixtures/with_namespace/example_1.mml
+++ b/spec/fixtures/with_namespace/example_1.mml
@@ -1,4 +1,4 @@
-<math xmlns="http://www.w3.org/1998/Math/MathML">
+<math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
   <mrow>
     <mi>i</mi>
     <mo>+</mo>

--- a/spec/fixtures/without_namespace/example_1.mml
+++ b/spec/fixtures/without_namespace/example_1.mml
@@ -1,4 +1,4 @@
-<math>
+<math display="block">
   <mrow>
     <mi>i</mi>
     <mo>+</mo>


### PR DESCRIPTION
This PR adds the `display` attribute for `Math` with/without the namespace, updates the constant's name used for **Plurimath-JS**, **lutaml-model** version, and `mn` tags content data type from `integer` to `string`.

related => unitsml/unitsml-ruby#27
related => plurimath/plurimath-js#28