### PR TITLE
Remove `zeitwerk` and Opal compatibility

### DIFF
--- a/lib/mml/common_attributes.rb
+++ b/lib/mml/common_attributes.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Mml
+  Mml::Configuration::SUPPORTED_TAGS.each do |tag|
+    autoload(tag.to_s.capitalize.to_sym, tag.to_s)
+  end
+
+  class CommonAttributes < Lutaml::Model::Serializable
+    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
+      attribute :"#{tag}_value", Mml.const_get(tag.to_s.capitalize), collection: true
+    end
+
+    xml do
+      no_root
+
+      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
+        map_element tag, to: :"#{tag}_value"
+      end
+    end
+  end
+end

--- a/lib/mml/configuration.rb
+++ b/lib/mml/configuration.rb
@@ -2,7 +2,7 @@
 
 module Mml
   module Configuration
-    SUPPORTED_TAGS = %w[
+    SUPPORTED_TAGS = %i[
       mmultiscripts
       maligngroup
       malignmark
@@ -40,6 +40,38 @@ module Mml
       mo
       mn
       ms
+    ].freeze
+
+    COMMON_ATTRIBUTES_CLASSES = %w[
+      MathWithNilNamespace
+      MathWithNamespace
+      Mmultiscripts
+      Munderover
+      Semantics
+      Mscarries
+      Mfraction
+      Mlongdiv
+      Mphantom
+      Menclose
+      Mfenced
+      Mpadded
+      Msubsup
+      Msgroup
+      Mscarry
+      Munder
+      Mstyle
+      Mstack
+      Merror
+      Mover
+      Mfrac
+      Msrow
+      Mroot
+      Msqrt
+      Mrow
+      Msub
+      Msup
+      Mtd
+      Ms
     ].freeze
 
     module_function

--- a/lib/mml/math_with_namespace.rb
+++ b/lib/mml/math_with_namespace.rb
@@ -2,19 +2,11 @@
 
 module Mml
   class MathWithNamespace < Lutaml::Model::Serializable
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
-
     attribute :display, :string
 
     xml do
       root "math", mixed: true
       namespace "http://www.w3.org/1998/Math/MathML", nil
-
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
 
       map_attribute :display, to: :display
     end

--- a/lib/mml/math_with_nil_namespace.rb
+++ b/lib/mml/math_with_nil_namespace.rb
@@ -2,18 +2,10 @@
 
 module Mml
   class MathWithNilNamespace < Lutaml::Model::Serializable
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
-
     attribute :display, :string
 
     xml do
       root "math", mixed: true
-
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
 
       map_attribute :display, to: :display
     end

--- a/lib/mml/menclose.rb
+++ b/lib/mml/menclose.rb
@@ -5,9 +5,6 @@ module Mml
     attribute :mathcolor, :string
     attribute :mathbackground, :string
     attribute :notation, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "menclose", mixed: true
@@ -15,9 +12,6 @@ module Mml
       map_attribute "mathcolor", to: :mathcolor, namespace: nil
       map_attribute "mathbackground", to: :mathbackground, namespace: nil
       map_attribute "notation", to: :notation, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/merror.rb
+++ b/lib/mml/merror.rb
@@ -4,18 +4,12 @@ module Mml
   class Merror < Lutaml::Model::Serializable
     attribute :mathbackground, :string
     attribute :mathcolor, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "merror", mixed: true
 
       map_attribute "mathcolor", to: :mathcolor, namespace: nil
       map_attribute "mathbackground", to: :mathbackground, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mfenced.rb
+++ b/lib/mml/mfenced.rb
@@ -8,9 +8,6 @@ module Mml
     attribute :content, :string
     attribute :close, :string
     attribute :open, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "mfenced", mixed: true
@@ -22,10 +19,6 @@ module Mml
       map_attribute "mathcolor", to: :mathcolor, namespace: nil
       map_attribute "close", to: :close, namespace: nil
       map_attribute "open", to: :open, namespace: nil
-
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mfrac.rb
+++ b/lib/mml/mfrac.rb
@@ -8,9 +8,6 @@ module Mml
     attribute :numalign, :string
     attribute :denomalign, :string
     attribute :bevelled, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "mfrac", mixed: true
@@ -21,9 +18,6 @@ module Mml
       map_attribute "numalign", to: :numalign, namespace: nil
       map_attribute "denomalign", to: :denomalign, namespace: nil
       map_attribute "bevelled", to: :bevelled, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mfraction.rb
+++ b/lib/mml/mfraction.rb
@@ -8,9 +8,6 @@ module Mml
     attribute :numalign, :string
     attribute :denomalign, :string
     attribute :bevelled, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "mfraction", mixed: true
@@ -21,9 +18,6 @@ module Mml
       map_attribute "numalign", to: :numalign, namespace: nil
       map_attribute "denomalign", to: :denomalign, namespace: nil
       map_attribute "bevelled", to: :bevelled, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mlabeledtr.rb
+++ b/lib/mml/mlabeledtr.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Mml
+  autoload(:Mtd, "mml/mtd")
+
   class Mlabeledtr < Lutaml::Model::Serializable
     attribute :mathbackground, :string
     attribute :columnalign, :string

--- a/lib/mml/mlongdiv.rb
+++ b/lib/mml/mlongdiv.rb
@@ -7,9 +7,6 @@ module Mml
     attribute :mathcolor, :string
     attribute :position, :integer
     attribute :shift, :integer
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "mlongdiv", mixed: true
@@ -19,9 +16,6 @@ module Mml
       map_attribute "mathcolor", to: :mathcolor, namespace: nil
       map_attribute "position", to: :position, namespace: nil
       map_attribute "shift", to: :shift, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mmultiscripts.rb
+++ b/lib/mml/mmultiscripts.rb
@@ -1,15 +1,14 @@
 # frozen_string_literal: true
 
 module Mml
+  autoload(:Mprescripts, "mml/mprescripts")
+
   class Mmultiscripts < Lutaml::Model::Serializable
     attribute :mathcolor, :string
     attribute :mathbackground, :string
     attribute :subscriptshift, :string
     attribute :superscriptshift, :string
     attribute :mprescripts_value, Mprescripts
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "mmultiscripts", mixed: true
@@ -19,9 +18,6 @@ module Mml
       map_attribute "subscriptshift", to: :subscriptshift, namespace: nil
       map_attribute "superscriptshift", to: :superscriptshift, namespace: nil
       map_element "mprescripts", to: :mprescripts_value
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mover.rb
+++ b/lib/mml/mover.rb
@@ -6,9 +6,6 @@ module Mml
     attribute :mathcolor, :string
     attribute :accent, :string
     attribute :align, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "mover", mixed: true
@@ -17,9 +14,6 @@ module Mml
       map_attribute "mathcolor", to: :mathcolor, namespace: nil
       map_attribute "accent", to: :accent, namespace: nil
       map_attribute "align", to: :align, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mpadded.rb
+++ b/lib/mml/mpadded.rb
@@ -9,9 +9,6 @@ module Mml
     attribute :lspace, :string
     attribute :depth, :string
     attribute :width, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "mpadded", mixed: true
@@ -23,9 +20,6 @@ module Mml
       map_attribute "lspace", to: :lspace, namespace: nil
       map_attribute "depth", to: :depth, namespace: nil
       map_attribute "width", to: :width, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mphantom.rb
+++ b/lib/mml/mphantom.rb
@@ -4,18 +4,12 @@ module Mml
   class Mphantom < Lutaml::Model::Serializable
     attribute :mathcolor, :string
     attribute :mathbackground, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "mphantom", mixed: true
 
       map_attribute "mathcolor", to: :mathcolor, namespace: nil
       map_attribute "mathbackground", to: :mathbackground, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mroot.rb
+++ b/lib/mml/mroot.rb
@@ -4,18 +4,12 @@ module Mml
   class Mroot < Lutaml::Model::Serializable
     attribute :mathcolor, :string
     attribute :mathbackground, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "mroot", mixed: true
 
       map_attribute "mathcolor", to: :mathcolor, namespace: nil
       map_attribute "mathbackground", to: :mathbackground, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mrow.rb
+++ b/lib/mml/mrow.rb
@@ -8,10 +8,6 @@ module Mml
     attribute :intent, :string
     attribute :dir, :string
 
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
-
     xml do
       root "mrow", mixed: true
 
@@ -20,10 +16,6 @@ module Mml
       map_attribute "intent", to: :intent, namespace: nil
       map_attribute "mathcolor", to: :mathcolor, namespace: nil
       map_attribute "mathbackground", to: :mathbackground, namespace: nil
-
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/ms.rb
+++ b/lib/mml/ms.rb
@@ -16,9 +16,6 @@ module Mml
     attribute :color, :string
     attribute :value, :string
     attribute :dir, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "ms", mixed: true
@@ -37,9 +34,6 @@ module Mml
       map_attribute "rquote", to: :rquote, namespace: nil
       map_attribute "color", to: :color, namespace: nil
       map_attribute "dir", to: :dir, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mscarries.rb
+++ b/lib/mml/mscarries.rb
@@ -8,9 +8,6 @@ module Mml
     attribute :position, :integer
     attribute :location, :string
     attribute :crossout, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "mscarries", mixed: true
@@ -21,9 +18,6 @@ module Mml
       map_attribute "position", to: :position, namespace: nil
       map_attribute "location", to: :location, namespace: nil
       map_attribute "crossout", to: :crossout, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mscarry.rb
+++ b/lib/mml/mscarry.rb
@@ -6,9 +6,6 @@ module Mml
     attribute :mathbackground, :string
     attribute :location, :string
     attribute :crossout, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "mscarry", mixed: true
@@ -17,9 +14,6 @@ module Mml
       map_attribute "mathbackground", to: :mathbackground, namespace: nil
       map_attribute "location", to: :location, namespace: nil
       map_attribute "crossout", to: :crossout, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/msgroup.rb
+++ b/lib/mml/msgroup.rb
@@ -6,13 +6,7 @@ module Mml
     attribute :mathbackground, :string
     attribute :position, :integer
     attribute :shift, :integer
-    attribute :mscarries_value, Mscarries, collection: true
-    attribute :msrow_value, Msrow, collection: true
     attribute :msgroup_text, :string
-
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "msgroup", mixed: true
@@ -22,9 +16,6 @@ module Mml
       map_attribute "mathbackground", to: :mathbackground, namespace: nil
       map_attribute "position", to: :position, namespace: nil
       map_attribute "shift", to: :shift, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/msqrt.rb
+++ b/lib/mml/msqrt.rb
@@ -4,19 +4,12 @@ module Mml
   class Msqrt < Lutaml::Model::Serializable
     attribute :mathcolor, :string
     attribute :mathbackground, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "msqrt", mixed: true
 
       map_attribute "mathcolor", to: :mathcolor, namespace: nil
       map_attribute "mathbackground", to: :mathbackground, namespace: nil
-
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/msrow.rb
+++ b/lib/mml/msrow.rb
@@ -5,9 +5,6 @@ module Mml
     attribute :mathcolor, :string
     attribute :mathbackground, :string
     attribute :position, :integer
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "msrow", mixed: true
@@ -15,10 +12,6 @@ module Mml
       map_attribute "mathcolor", to: :mathcolor, namespace: nil
       map_attribute "mathbackground", to: :mathbackground, namespace: nil
       map_attribute "position", to: :position, namespace: nil
-
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mstack.rb
+++ b/lib/mml/mstack.rb
@@ -8,9 +8,6 @@ module Mml
     attribute :stackalign, :string
     attribute :charalign, :string
     attribute :charspacing, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "mstack", mixed: true
@@ -21,9 +18,6 @@ module Mml
       map_attribute "stackalign", to: :stackalign, namespace: nil
       map_attribute "charalign", to: :charalign, namespace: nil
       map_attribute "charspacing", to: :charspacing, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mstyle.rb
+++ b/lib/mml/mstyle.rb
@@ -99,9 +99,6 @@ module Mml
     attribute :thickmathspace, :string
     attribute :verythickmathspace, :string
     attribute :veryverythickmathspace, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     # rubocop:disable Metrics/BlockLength
     xml do
@@ -203,9 +200,6 @@ module Mml
       map_attribute "thickmathspace", to: :thickmathspace, namespace: nil
       map_attribute "verythickmathspace", to: :verythickmathspace, namespace: nil
       map_attribute "veryverythickmathspace", to: :veryverythickmathspace, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
     # rubocop:enable Metrics/BlockLength
   end

--- a/lib/mml/msub.rb
+++ b/lib/mml/msub.rb
@@ -5,9 +5,6 @@ module Mml
     attribute :mathbackground, :string
     attribute :subscriptshift, :string
     attribute :mathcolor, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "msub", mixed: true
@@ -15,9 +12,6 @@ module Mml
       map_attribute "mathbackground", to: :mathbackground, namespace: nil
       map_attribute "subscriptshift", to: :subscriptshift, namespace: nil
       map_attribute "mathcolor", to: :mathcolor, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/msubsup.rb
+++ b/lib/mml/msubsup.rb
@@ -6,9 +6,6 @@ module Mml
     attribute :mathbackground, :string
     attribute :subscriptshift, :string
     attribute :superscriptshift, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "msubsup", mixed: true
@@ -17,9 +14,6 @@ module Mml
       map_attribute "mathbackground", to: :mathbackground, namespace: nil
       map_attribute "subscriptshift", to: :subscriptshift, namespace: nil
       map_attribute "superscriptshift", to: :superscriptshift, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/msup.rb
+++ b/lib/mml/msup.rb
@@ -5,9 +5,6 @@ module Mml
     attribute :mathcolor, :string
     attribute :mathbackground, :string
     attribute :superscriptshift, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "msup", mixed: true
@@ -15,9 +12,6 @@ module Mml
       map_attribute "mathcolor", to: :mathcolor, namespace: nil
       map_attribute "mathbackground", to: :mathbackground, namespace: nil
       map_attribute "superscriptshift", to: :superscriptshift, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mtable.rb
+++ b/lib/mml/mtable.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Mml
+  autoload(:Mlabeledtr, "mml/mlabeledtr")
+  autoload(:Mtr, "mml/mtr")
   class Mtable < Lutaml::Model::Serializable
     attribute :mathcolor, :string
     attribute :mathbackground, :string

--- a/lib/mml/mtd.rb
+++ b/lib/mml/mtd.rb
@@ -6,9 +6,6 @@ module Mml
     attribute :mathbackground, :string
     attribute :rowalign, :string
     attribute :columnalign, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "mtd", mixed: true
@@ -17,9 +14,6 @@ module Mml
       map_attribute "mathbackground", to: :mathbackground, namespace: nil
       map_attribute "rowalign", to: :rowalign, namespace: nil
       map_attribute "columnalign", to: :columnalign, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/mtr.rb
+++ b/lib/mml/mtr.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module Mml
+  autoload(:Mtd, "mml/mtd")
+
   class Mtr < Lutaml::Model::Serializable
     attribute :mathcolor, :string
     attribute :mathbackground, :string

--- a/lib/mml/munder.rb
+++ b/lib/mml/munder.rb
@@ -7,9 +7,6 @@ module Mml
     attribute :mathcolor, :string
     attribute :content, :string
     attribute :align, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "munder", mixed: true
@@ -19,9 +16,6 @@ module Mml
       map_attribute "mathcolor", to: :mathcolor, namespace: nil
       map_attribute "align", to: :align, namespace: nil
       map_content to: :content
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/munderover.rb
+++ b/lib/mml/munderover.rb
@@ -7,9 +7,6 @@ module Mml
     attribute :accent, :string
     attribute :accentunder, :string
     attribute :align, :string
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
 
     xml do
       root "munderover", mixed: true
@@ -19,9 +16,6 @@ module Mml
       map_attribute "accent", to: :accent, namespace: nil
       map_attribute "accentunder", to: :accentunder, namespace: nil
       map_attribute "align", to: :align, namespace: nil
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/lib/mml/opal_setup.rb.erb
+++ b/lib/mml/opal_setup.rb.erb
@@ -1,0 +1,6 @@
+<%
+  files = Dir["#{__dir__}/*.rb"].reject { |file| ["common_attributes", "opal_setup"].include?(File.basename(file, ".rb")) }
+  files.each do |file_name|
+%>
+  require 'mml/<%= File.basename(file_name, ".rb") %>'
+<% end %>

--- a/lib/mml/semantics.rb
+++ b/lib/mml/semantics.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
 
 module Mml
+  autoload(:Mi, "mml/mi")
+
   class Semantics < Lutaml::Model::Serializable
-    attribute :annotation, Mml::Mi, collection: true
-    Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-      attribute :"#{tag}_value", Mml.const_get(tag.capitalize), collection: true
-    end
+    attribute :annotation, Mi, collection: true
 
     xml do
       root "semantics", mixed: true
 
       map_element :annotation, to: :annotation
-      Mml::Configuration::SUPPORTED_TAGS.each do |tag|
-        map_element tag.to_sym, to: :"#{tag}_value"
-      end
     end
   end
 end

--- a/mml.gemspec
+++ b/mml.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "lutaml-model"
-  spec.add_runtime_dependency "zeitwerk"
+  spec.add_runtime_dependency "moxml"
 end


### PR DESCRIPTION
This PR removes `zeitwerk` dependency, updates the attribute definition strucutre.

closes #6 
related => plurimath/plurimath-js#35