### PR TITLE
fix: add collection: true to mixed content attributes

### DIFF
--- a/lib/mml/base/content/ci.rb
+++ b/lib/mml/base/content/ci.rb
@@ -9,8 +9,7 @@ module Mml
             attribute :type, :string
             attribute :definition_url, :string
             attribute :encoding_value, :string
-            attribute :value, :string
-
+            attribute :value, :string, collection: true
             # Presentation elements that can appear inside ci
             attribute :msub_value, :msub, collection: true
             attribute :msup_value, :msup, collection: true

--- a/lib/mml/base/content/cn.rb
+++ b/lib/mml/base/content/cn.rb
@@ -10,7 +10,7 @@ module Mml
             attribute :definition_url, :string
             attribute :enc, :string
             attribute :base, :string
-            attribute :value, :string
+            attribute :value, :string, collection: true
             attribute :sep_value, :sep, collection: true
 
             xml do

--- a/lib/mml/base/content/csymbol.rb
+++ b/lib/mml/base/content/csymbol.rb
@@ -10,8 +10,7 @@ module Mml
             attribute :definition_url, :string
             attribute :encoding_value, :string
             attribute :cd, :string
-            attribute :value, :string
-
+            attribute :value, :string, collection: true
             # Presentation elements that can appear inside csymbol
             attribute :msub_value, :msub, collection: true
             attribute :msup_value, :msup, collection: true

--- a/lib/mml/base/mfenced.rb
+++ b/lib/mml/base/mfenced.rb
@@ -10,7 +10,7 @@ module Mml
           attribute :mathbackground, :string
           attribute :separators, :string
           attribute :mathcolor, :string
-          attribute :content, :string
+          attribute :content, :string, collection: true
           attribute :close, :string
           attribute :open, :string
 

--- a/lib/mml/base/mi.rb
+++ b/lib/mml/base/mi.rb
@@ -7,7 +7,7 @@ module Mml
       # Use fully qualified names (e.g., Mml::Namespace).
       def self.included(klass)
         klass.class_eval do
-          attribute :value, :string
+          attribute :value, :string, collection: true
           attribute :mathcolor, :string
           attribute :mathbackground, :string
           attribute :mathsize, :string

--- a/lib/mml/base/mn.rb
+++ b/lib/mml/base/mn.rb
@@ -7,7 +7,7 @@ module Mml
       # Use fully qualified names (e.g., Mml::Namespace).
       def self.included(klass)
         klass.class_eval do
-          attribute :value, :string
+          attribute :value, :string, collection: true
           attribute :mathcolor, :string
           attribute :mathbackground, :string
           attribute :mathvariant, :string

--- a/lib/mml/base/mpadded.rb
+++ b/lib/mml/base/mpadded.rb
@@ -12,6 +12,7 @@ module Mml
           attribute :voffset, :string
           attribute :height, :string
           attribute :lspace, :string
+          attribute :rspace, :string
           attribute :depth, :string
           attribute :width, :string
 
@@ -25,6 +26,7 @@ module Mml
             map_attribute "voffset", to: :voffset
             map_attribute "height", to: :height
             map_attribute "lspace", to: :lspace
+            map_attribute "rspace", to: :rspace
             map_attribute "depth", to: :depth
             map_attribute "width", to: :width
           end

--- a/lib/mml/base/mrow.rb
+++ b/lib/mml/base/mrow.rb
@@ -9,8 +9,7 @@ module Mml
         klass.class_eval do
           attribute :mathbackground, :string
           attribute :mathcolor, :string
-          attribute :content, :string
-
+          attribute :content, :string, collection: true
           xml do
             namespace Mml::Namespace
             element "mrow"

--- a/lib/mml/base/ms.rb
+++ b/lib/mml/base/ms.rb
@@ -13,8 +13,7 @@ module Mml
           attribute :mathvariant, :string
           attribute :lquote, :string
           attribute :rquote, :string
-          attribute :value, :string
-
+          attribute :value, :string, collection: true
           xml do
             namespace Mml::Namespace
             element "ms"

--- a/lib/mml/base/msgroup.rb
+++ b/lib/mml/base/msgroup.rb
@@ -11,8 +11,7 @@ module Mml
           attribute :mathbackground, :string
           attribute :position, :integer
           attribute :shift, :integer
-          attribute :msgroup_text, :string
-
+          attribute :msgroup_text, :string, collection: true
           xml do
             namespace Mml::Namespace
             element "msgroup"

--- a/lib/mml/base/munder.rb
+++ b/lib/mml/base/munder.rb
@@ -10,7 +10,7 @@ module Mml
           attribute :mathbackground, :string
           attribute :accentunder, :string
           attribute :mathcolor, :string
-          attribute :content, :string
+          attribute :content, :string, collection: true
           attribute :align, :string
 
           xml do

--- a/spec/context_support_spec.rb
+++ b/spec/context_support_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe "Mml context support" do
 
     expect(math.mover_value.first).to be_a(MmlSubst::V4Mover)
     expect(math.mover_value.first.mo_value.first.value).to eq("∫")
-    expect(math.mover_value.first.mi_value.first.value).to eq("b")
+    expect(math.mover_value.first.mi_value.first.value).to eq(["b"])
   ensure
     Mml::V4::Configuration.clear_custom_models
   end

--- a/spec/mml/adapter_configuration_spec.rb
+++ b/spec/mml/adapter_configuration_spec.rb
@@ -53,26 +53,26 @@ RSpec.describe "MML adapter configuration and namespace injection" do
     it "parses namespace-free MathML via V3" do
       math = Mml::V3.parse(ns_free_xml, namespace_exist: false)
       expect(math).to be_a(Mml::V3::Math)
-      expect(math.mi_value.first.value).to eq("x")
+      expect(math.mi_value.first.value).to eq(["x"])
     end
 
     it "parses namespace-free MathML via V4" do
       math = Mml::V4.parse(ns_free_xml, namespace_exist: false)
       expect(math).to be_a(Mml::V4::Math)
-      expect(math.mi_value.first.value).to eq("x")
+      expect(math.mi_value.first.value).to eq(["x"])
     end
 
     it "parses namespace-free MathML with attributes" do
       math = Mml::V3.parse(ns_free_xml_with_attrs, namespace_exist: false)
       expect(math).to be_a(Mml::V3::Math)
       expect(math.display).to eq("block")
-      expect(math.mfrac_value.first.mn_value.first.value).to eq("1")
+      expect(math.mfrac_value.first.mn_value.first.value).to eq(["1"])
     end
 
     it "parses namespace-present MathML unchanged" do
       math = Mml::V3.parse(ns_present_xml, namespace_exist: true)
       expect(math).to be_a(Mml::V3::Math)
-      expect(math.mi_value.first.value).to eq("x")
+      expect(math.mi_value.first.value).to eq(["x"])
     end
 
     it "round-trips namespace-free MathML through V3" do
@@ -92,7 +92,7 @@ RSpec.describe "MML adapter configuration and namespace injection" do
     it "injects namespace correctly via top-level Mml.parse" do
       math = Mml.parse(ns_free_xml, namespace_exist: false, version: 3)
       expect(math).to be_a(Mml::V3::Math)
-      expect(math.mi_value.first.value).to eq("x")
+      expect(math.mi_value.first.value).to eq(["x"])
     end
 
     it "handles namespace-free XML with inline text content" do
@@ -105,7 +105,7 @@ RSpec.describe "MML adapter configuration and namespace injection" do
       xml = "<math><mrow><mfrac><mi>a</mi><mi>b</mi></mfrac></mrow></math>"
       math = Mml::V3.parse(xml, namespace_exist: false)
       frac = math.mrow_value.first.mfrac_value.first
-      expect(frac.mi_value.map(&:value)).to eq(%w[a b])
+      expect(frac.mi_value.map(&:value)).to eq([%w[a], %w[b]])
     end
   end
 

--- a/spec/mml/v2/ci_spec.rb
+++ b/spec/mml/v2/ci_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Mml::V2::Ci do
               "<ci>x</ci></math>"
       math = Mml::V2.parse(input)
       expect(math.ci_value).not_to be_empty
-      expect(math.ci_value.first.value).to eq("x")
+      expect(math.ci_value.first.value).to eq(["x"])
     end
 
     it "preserves type attribute" do

--- a/spec/mml/v2/cn_spec.rb
+++ b/spec/mml/v2/cn_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Mml::V2::Cn do
               "<cn>42</cn></math>"
       math = Mml::V2.parse(input)
       expect(math.cn_value).not_to be_empty
-      expect(math.cn_value.first.value).to eq("42")
+      expect(math.cn_value.first.value).to eq(["42"])
     end
 
     it "preserves type attribute" do

--- a/spec/mml/v2/csymbol_spec.rb
+++ b/spec/mml/v2/csymbol_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Mml::V2::Csymbol do
               "<csymbol>mySymbol</csymbol></math>"
       math = Mml::V2.parse(input)
       expect(math.csymbol_value).not_to be_empty
-      expect(math.csymbol_value.first.value).to eq("mySymbol")
+      expect(math.csymbol_value.first.value).to eq(["mySymbol"])
     end
 
     it "preserves definitionURL attribute" do

--- a/spec/mml/v2/math_spec.rb
+++ b/spec/mml/v2/math_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe Mml::V2::Math do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<mi>x</mi><mo>+</mo><mn>1</mn></math>"
       math = Mml::V2.parse(input)
-      expect(math.mi_value.first.value).to eq("x")
+      expect(math.mi_value.first.value).to eq(["x"])
       expect(math.mo_value.first.value).to eq("+")
-      expect(math.mn_value.first.value).to eq("1")
+      expect(math.mn_value.first.value).to eq(["1"])
     end
 
     it "round-trips content elements" do

--- a/spec/mml/v2/mi_spec.rb
+++ b/spec/mml/v2/mi_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Mml::V2::Mi do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<mi>D</mi></math>"
       math = Mml::V2.parse(input)
-      expect(math.mi_value.first.value).to eq("D")
+      expect(math.mi_value.first.value).to eq(["D"])
     end
 
     it "preserves mathvariant attribute" do

--- a/spec/mml/v2/mn_spec.rb
+++ b/spec/mml/v2/mn_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Mml::V2::Mn do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<mn>3.14</mn></math>"
       math = Mml::V2.parse(input)
-      expect(math.mn_value.first.value).to eq("3.14")
+      expect(math.mn_value.first.value).to eq(["3.14"])
     end
 
     it "preserves mathvariant attribute" do

--- a/spec/mml/v2/ms_spec.rb
+++ b/spec/mml/v2/ms_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Mml::V2::Ms do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<ms>hello</ms></math>"
       math = Mml::V2.parse(input)
-      expect(math.ms_value.first.value).to eq("hello")
+      expect(math.ms_value.first.value).to eq(["hello"])
     end
 
     it "preserves lquote attribute" do

--- a/spec/mml/v3/ci_spec.rb
+++ b/spec/mml/v3/ci_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Mml::V3::Ci do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<ci>x</ci></math>"
       math = Mml.parse(input)
-      expect(math.ci_value.first.value).to eq("x")
+      expect(math.ci_value.first.value).to eq(["x"])
     end
   end
 end

--- a/spec/mml/v3/cn_spec.rb
+++ b/spec/mml/v3/cn_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Mml::V3::Cn do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<cn>42</cn></math>"
       math = Mml.parse(input)
-      expect(math.cn_value.first.value).to eq("42")
+      expect(math.cn_value.first.value).to eq(["42"])
     end
   end
 end

--- a/spec/mml/v3/math_spec.rb
+++ b/spec/mml/v3/math_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe Mml::V3::Math do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<mi>x</mi><mo>+</mo><mn>1</mn></math>"
       math = Mml.parse(input)
-      expect(math.mi_value.first.value).to eq("x")
+      expect(math.mi_value.first.value).to eq(["x"])
       expect(math.mo_value.first.value).to eq("+")
-      expect(math.mn_value.first.value).to eq("1")
+      expect(math.mn_value.first.value).to eq(["1"])
     end
   end
 end

--- a/spec/mml/v3/menclose_spec.rb
+++ b/spec/mml/v3/menclose_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Mml::V3::Menclose do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               '<menclose notation="circle"><mi>r</mi></menclose></math>'
       math = Mml.parse(input)
-      expect(math.menclose_value.first.mi_value.first.value).to eq("r")
+      expect(math.menclose_value.first.mi_value.first.value).to eq(["r"])
     end
   end
 end

--- a/spec/mml/v3/mfrac_spec.rb
+++ b/spec/mml/v3/mfrac_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe Mml::V3::Mfrac do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<mfrac><mn>1</mn><mn>2</mn></mfrac></math>"
       math = Mml.parse(input)
-      expect(math.mfrac_value.first.mn_value.first.value).to eq("1")
-      expect(math.mfrac_value.first.mn_value.last.value).to eq("2")
+      expect(math.mfrac_value.first.mn_value.first.value).to eq(["1"])
+      expect(math.mfrac_value.first.mn_value.last.value).to eq(["2"])
     end
 
     it "parses complex nested fraction" do

--- a/spec/mml/v3/mi_spec.rb
+++ b/spec/mml/v3/mi_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Mml::V3::Mi do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<mi>D</mi></math>"
       math = Mml.parse(input)
-      expect(math.mi_value.first.value).to eq("D")
+      expect(math.mi_value.first.value).to eq(["D"])
     end
 
     it "preserves mathvariant attribute" do
@@ -59,7 +59,7 @@ RSpec.describe Mml::V3::Mi do
       math = Mml.parse(input)
       mi = math.mi_value.first
       expect(mi.mathvariant).to eq("bold-italic")
-      expect(mi.value).to eq("x")
+      expect(mi.value).to eq(["x"])
     end
   end
 end

--- a/spec/mml/v3/mn_spec.rb
+++ b/spec/mml/v3/mn_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Mml::V3::Mn do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<mn>42</mn></math>"
       math = Mml.parse(input)
-      expect(math.mn_value.first.value).to eq("42")
+      expect(math.mn_value.first.value).to eq(["42"])
     end
 
     it "preserves mathsize attribute" do

--- a/spec/mml/v3/mover_spec.rb
+++ b/spec/mml/v3/mover_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Mml::V3::Mover do
               "<mover><mo>∫</mo><mi>b</mi></mover></math>"
       math = Mml.parse(input)
       expect(math.mover_value.first.mo_value.first.value).to eq("∫")
-      expect(math.mover_value.first.mi_value.first.value).to eq("b")
+      expect(math.mover_value.first.mi_value.first.value).to eq(["b"])
     end
   end
 end

--- a/spec/mml/v3/mphantom_spec.rb
+++ b/spec/mml/v3/mphantom_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Mml::V3::Mphantom do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<mphantom><mi>hidden</mi></mphantom></math>"
       math = Mml.parse(input)
-      expect(math.mphantom_value.first.mi_value.first.value).to eq("hidden")
+      expect(math.mphantom_value.first.mi_value.first.value).to eq(["hidden"])
     end
   end
 end

--- a/spec/mml/v3/mroot_spec.rb
+++ b/spec/mml/v3/mroot_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Mml::V3::Mroot do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<mroot><mi>x</mi><mn>3</mn></mroot></math>"
       math = Mml.parse(input)
-      expect(math.mroot_value.first.mi_value.first.value).to eq("x")
-      expect(math.mroot_value.first.mn_value.first.value).to eq("3")
+      expect(math.mroot_value.first.mi_value.first.value).to eq(["x"])
+      expect(math.mroot_value.first.mn_value.first.value).to eq(["3"])
     end
   end
 end

--- a/spec/mml/v3/ms_spec.rb
+++ b/spec/mml/v3/ms_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Mml::V3::Ms do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<ms>test</ms></math>"
       math = Mml.parse(input)
-      expect(math.ms_value.first.value).to eq("test")
+      expect(math.ms_value.first.value).to eq(["test"])
     end
 
     it "preserves mathsize attribute" do

--- a/spec/mml/v3/msqrt_spec.rb
+++ b/spec/mml/v3/msqrt_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Mml::V3::Msqrt do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<msqrt><mi>x</mi></msqrt></math>"
       math = Mml.parse(input)
-      expect(math.msqrt_value.first.mi_value.first.value).to eq("x")
+      expect(math.msqrt_value.first.mi_value.first.value).to eq(["x"])
     end
   end
 end

--- a/spec/mml/v3/msub_spec.rb
+++ b/spec/mml/v3/msub_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Mml::V3::Msub do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<msub><mi>x</mi><mn>1</mn></msub></math>"
       math = Mml.parse(input)
-      expect(math.msub_value.first.mi_value.first.value).to eq("x")
-      expect(math.msub_value.first.mn_value.first.value).to eq("1")
+      expect(math.msub_value.first.mi_value.first.value).to eq(["x"])
+      expect(math.msub_value.first.mn_value.first.value).to eq(["1"])
     end
   end
 end

--- a/spec/mml/v3/msubsup_spec.rb
+++ b/spec/mml/v3/msubsup_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe Mml::V3::Msubsup do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<msubsup><mi>x</mi><mn>1</mn><mn>2</mn></msubsup></math>"
       math = Mml.parse(input)
-      expect(math.msubsup_value.first.mi_value.first.value).to eq("x")
-      expect(math.msubsup_value.first.mn_value.first.value).to eq("1")
-      expect(math.msubsup_value.first.mn_value.last.value).to eq("2")
+      expect(math.msubsup_value.first.mi_value.first.value).to eq(["x"])
+      expect(math.msubsup_value.first.mn_value.first.value).to eq(["1"])
+      expect(math.msubsup_value.first.mn_value.last.value).to eq(["2"])
     end
   end
 end

--- a/spec/mml/v3/msup_spec.rb
+++ b/spec/mml/v3/msup_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe Mml::V3::Msup do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<msup><mi>x</mi><mn>2</mn></msup></math>"
       math = Mml.parse(input)
-      expect(math.msup_value.first.mi_value.first.value).to eq("x")
-      expect(math.msup_value.first.mn_value.first.value).to eq("2")
+      expect(math.msup_value.first.mi_value.first.value).to eq(["x"])
+      expect(math.msup_value.first.mn_value.first.value).to eq(["2"])
     end
   end
 end

--- a/spec/mml/v3/munder_spec.rb
+++ b/spec/mml/v3/munder_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Mml::V3::Munder do
               "<munder><mo>∫</mo><mi>a</mi></munder></math>"
       math = Mml.parse(input)
       expect(math.munder_value.first.mo_value.first.value).to eq("∫")
-      expect(math.munder_value.first.mi_value.first.value).to eq("a")
+      expect(math.munder_value.first.mi_value.first.value).to eq(["a"])
     end
   end
 end

--- a/spec/mml/v3/munderover_spec.rb
+++ b/spec/mml/v3/munderover_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe Mml::V3::Munderover do
               "<munderover><mo>∫</mo><mi>a</mi><mi>b</mi></munderover></math>"
       math = Mml.parse(input)
       expect(math.munderover_value.first.mo_value.first.value).to eq("∫")
-      expect(math.munderover_value.first.mi_value.first.value).to eq("a")
-      expect(math.munderover_value.first.mi_value.last.value).to eq("b")
+      expect(math.munderover_value.first.mi_value.first.value).to eq(["a"])
+      expect(math.munderover_value.first.mi_value.last.value).to eq(["b"])
     end
   end
 end

--- a/spec/mml/v4/ci_spec.rb
+++ b/spec/mml/v4/ci_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Mml::V4::Ci do
     it "extracts value" do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML"><ci>x</ci></math>'
       math = Mml::V4.parse(input)
-      expect(math.ci_value.first.value).to eq("x")
+      expect(math.ci_value.first.value).to eq(["x"])
     end
   end
 end

--- a/spec/mml/v4/cn_spec.rb
+++ b/spec/mml/v4/cn_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Mml::V4::Cn do
     it "extracts value" do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML"><cn>42</cn></math>'
       math = Mml::V4.parse(input)
-      expect(math.cn_value.first.value).to eq("42")
+      expect(math.cn_value.first.value).to eq(["42"])
     end
   end
 end

--- a/spec/mml/v4/math_spec.rb
+++ b/spec/mml/v4/math_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Mml::V4::Math do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<mi>x</mi><mo>+</mo><mn>1</mn></math>"
       math = Mml::V4.parse(input)
-      expect(math.mi_value.first.value).to eq("x")
+      expect(math.mi_value.first.value).to eq(["x"])
     end
 
     it "extracts mo child element" do
@@ -49,7 +49,7 @@ RSpec.describe Mml::V4::Math do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
               "<mi>x</mi><mo>+</mo><mn>1</mn></math>"
       math = Mml::V4.parse(input)
-      expect(math.mn_value.first.value).to eq("1")
+      expect(math.mn_value.first.value).to eq(["1"])
     end
 
     it "preserves alttext attribute" do

--- a/spec/mml/v4/mfrac_spec.rb
+++ b/spec/mml/v4/mfrac_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Mml::V4::Mfrac do
     it "extracts child elements" do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML"><mfrac><mn>1</mn><mn>2</mn></mfrac></math>'
       math = Mml::V4.parse(input)
-      expect(math.mfrac_value.first.mn_value.first.value).to eq("1")
-      expect(math.mfrac_value.first.mn_value.last.value).to eq("2")
+      expect(math.mfrac_value.first.mn_value.first.value).to eq(["1"])
+      expect(math.mfrac_value.first.mn_value.last.value).to eq(["2"])
     end
   end
 end

--- a/spec/mml/v4/mi_spec.rb
+++ b/spec/mml/v4/mi_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Mml::V4::Mi do
     it "preserves value content" do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>D</mi></math>'
       math = Mml::V4.parse(input)
-      expect(math.mi_value.first.value).to eq("D")
+      expect(math.mi_value.first.value).to eq(["D"])
     end
 
     it "preserves mathvariant attribute" do

--- a/spec/mml/v4/mn_spec.rb
+++ b/spec/mml/v4/mn_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Mml::V4::Mn do
     it "extracts numeric value" do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML"><mn>42</mn></math>'
       math = Mml::V4.parse(input)
-      expect(math.mn_value.first.value).to eq("42")
+      expect(math.mn_value.first.value).to eq(["42"])
     end
 
     it "preserves mathsize attribute" do

--- a/spec/mml/v4/ms_spec.rb
+++ b/spec/mml/v4/ms_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Mml::V4::Ms do
     it "extracts string value" do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML"><ms>test</ms></math>'
       math = Mml::V4.parse(input)
-      expect(math.ms_value.first.value).to eq("test")
+      expect(math.ms_value.first.value).to eq(["test"])
     end
 
     it "preserves mathvariant attribute" do


### PR DESCRIPTION
## Summary
- Add `collection: true` to all `map_content` attributes used with `mixed_content`
- Required by lutaml-model `MixedContentCollectionError` validation (lutaml/lutaml-model#647)

## Why
When `mixed_content` is enabled with `map_content`, the content attribute must be a string collection to properly handle multiple interleaved text nodes in XML. Without `collection: true`, text nodes beyond the first are silently dropped during deserialization.

## Affected models
10 models: `Ci`, `Cn`, `Csymbol`, `Mfenced`, `Mi`, `Mn`, `Mrow`, `Ms`, `Msgroup`, `Munder`