### PR TITLE
fix: remove spurious backslash escaping in mstyle spec

### DIFF
--- a/spec/mml/v3/mstyle_spec.rb
+++ b/spec/mml/v3/mstyle_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Mml::V3::Mstyle do
 
     it "parses mstyle with child elements" do
       input = '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
-              '<mstyle mathcolor=\"red\"><mi>y</mi></mstyle></math>'
+              '<mstyle mathcolor="red"><mi>y</mi></mstyle></math>'
       output = Mml.parse(input).to_xml
       expect(output).to be_xml_equivalent_to(input)
     end


### PR DESCRIPTION
The `mathcolor=\"red\"` in `spec/mml/v3/mstyle_spec.rb:16` uses `\"` inside a single-quoted Ruby string. In single quotes, `\"` is not an escape — it produces literal `\` characters in the XML input, creating invalid markup:

```
mathcolor=\"red\"  ←  invalid XML (backslashes before quotes)
mathcolor="red"    ←  valid XML
```

Nokogiri's error recovery parses the garbled input differently, causing the round-trip test to fail. The fix removes the spurious backslashes, matching the pattern used in the adjacent `preserves mathcolor attribute` test on line 23.

This is a pre-existing test bug unrelated to the lutaml-model processing-instructions branch (lutaml/lutaml-model#662).